### PR TITLE
Wraps apt::unattended-upgrades

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,4 +19,7 @@ suites:
     run_list:
       - recipe[stackup-base::default]
     attributes:
-
+      apt:
+        unattended_upgrades:
+          mail: 'foo@example.com'
+          automatic_reboot_time: '02:00'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This cookbook will bootstrap a node. This cookbook is made for stack-up stacks, 
  * installs ntpd
  * installs default packages
  * installs packages defined by node['base']['extra_packages']
+ * enables unattended-upgrades
 
 ---
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,9 +1,3 @@
 default['apt']['compile_time_update'] = true
 
 default['base']['extra_packages'] = []
-
-default['base']['unattended-upgrades']['Mail'] = 'foo@example.com'
-default['base']['unattended-upgrades']['MailOnlyOnError'] = 'true'
-default['base']['unattended-upgrades']['Automatic-Reboot'] = 'true'
-default['base']['unattended-upgrades']['Automatic-Reboot-Time'] = '02:00'
-default['base']['unattended-upgrades']['Dl-Limit'] = '70'

--- a/attributes/unattended_upgrades.rb
+++ b/attributes/unattended_upgrades.rb
@@ -1,0 +1,10 @@
+default['apt']['unattended_upgrades']['enabled'] = true
+
+default['apt']['unattended_upgrades']['allowed_origins'] = [
+  '${distro_id}:${distro_codename}-security'
+]
+
+default['apt']['unattended_upgrades']['automatic_reboot'] = 'true'
+default['apt']['unattended_upgrades']['automatic_reboot_time'] = '04:00'
+default['apt']['unattended_upgrades']['dl_limit'] = 70
+default['apt']['unattended_upgrades']['mail'] = false

--- a/files/default/20auto-upgrades
+++ b/files/default/20auto-upgrades
@@ -1,2 +1,0 @@
-APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Unattended-Upgrade "1";

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license 'MIT'
 description 'Installs/Configures stackup-base'
 long_description 'Installs/Configures stackup-base'
 
-version '0.4.0'
+version '0.5.0'
 
 supports 'ubuntu'
 

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,5 +1,4 @@
 %w(
-  bsd-mailx
   build-essential
   git
   git-extras

--- a/recipes/unattended_upgrades.rb
+++ b/recipes/unattended_upgrades.rb
@@ -1,16 +1,15 @@
-package 'unattended-upgrades'
+include_recipe 'apt::unattended-upgrades'
 
-cookbook_file '/etc/apt/apt.conf.d/20auto-upgrades' do
-  source '20auto-upgrades'
+# wraps apt@2.6.0::unattended-upgrades:32
+if node['apt']['unattended_upgrades']['mail']
+  # mailutils is clearly in master: http://goo.gl/iQRNeF
+  # but it seems they haven't bumped their version after adding it,
+  # so I'm redefining package 'mailtuils' here.
+  package 'mailutils'
+  resources('package[mailutils]').package_name 'bsd-mailx'
 end
 
-cookbook_file '/etc/apt/apt.conf.d/50unattended-upgrades' do
-  source '50unattended-upgrades'
-end
-
-template '/etc/apt/apt.conf.d/50unattended-upgrades' do
-  source '50unattended-upgrades.erb'
-  variables(
-    unattended_upgrades: node['base']['unattended-upgrades']
-  )
-end
+# wraps apt@2.6.0::unattended-upgrades:42
+resources(
+  'template[/etc/apt/apt.conf.d/50unattended-upgrades]'
+).cookbook 'stackup-base'

--- a/templates/default/50unattended-upgrades.erb
+++ b/templates/default/50unattended-upgrades.erb
@@ -1,59 +1,68 @@
 // Automatically upgrade packages from these (origin:archive) pairs
 Unattended-Upgrade::Allowed-Origins {
-        "${distro_id}:${distro_codename}-security";
-//      "${distro_id}:${distro_codename}-updates";
-//      "${distro_id}:${distro_codename}-proposed";
-//      "${distro_id}:${distro_codename}-backports";
+<% unless node['apt']['unattended_upgrades']['allowed_origins'].empty? -%>
+<% node['apt']['unattended_upgrades']['allowed_origins'].each do |origin| -%>
+	"<%= origin %>";
+<% end -%>
+<% end -%>
 };
 
-// List of packages to not update (regexp are supported)
+
+// List of packages to not update
 Unattended-Upgrade::Package-Blacklist {
-//      "vim";
-//      "libc6";
-//      "libc6-dev";
-//      "libc6-i686";
+<% unless node['apt']['unattended_upgrades']['package_blacklist'].empty? -%>
+<% node['apt']['unattended_upgrades']['package_blacklist'].each do |package| -%>
+	"<%= package %>";
+<% end -%>
+<% end -%>
 };
 
 // This option allows you to control if on a unclean dpkg exit
-// unattended-upgrades will automatically run
+// unattended-upgrades will automatically run 
 //   dpkg --force-confold --configure -a
 // The default is true, to ensure updates keep getting installed
-//Unattended-Upgrade::AutoFixInterruptedDpkg "false";
+Unattended-Upgrade::AutoFixInterruptedDpkg "<%= node['apt']['unattended_upgrades']['auto_fix_interrupted_dpkg'] ? 'true' : 'false' %>";
 
 // Split the upgrade into the smallest possible chunks so that
 // they can be interrupted with SIGUSR1. This makes the upgrade
 // a bit slower but it has the benefit that shutdown while a upgrade
 // is running is possible (with a small delay)
-//Unattended-Upgrade::MinimalSteps "true";
+Unattended-Upgrade::MinimalSteps "<%= node['apt']['unattended_upgrades']['minimal_steps'] ? 'true' : 'false' %>";
 
 // Install all unattended-upgrades when the machine is shuting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
-//Unattended-Upgrade::InstallOnShutdown "true";
+Unattended-Upgrade::InstallOnShutdown "<%= node['apt']['unattended_upgrades']['install_on_shutdown'] ? 'true' : 'false' %>";
 
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you
 // have a working mail setup on your system. A package that provides
-// 'mailx' must be installed. E.g. "user@example.com"
-Unattended-Upgrade::Mail "<%= @unattended_upgrades['Mail'] %>";
+// 'mailx' must be installed.
+<% if node['apt']['unattended_upgrades']['mail'] -%>
+Unattended-Upgrade::Mail "<%= node['apt']['unattended_upgrades']['mail'] %>";
+<% end -%>
 
 // Set this value to "true" to get emails only on errors. Default
 // is to always send a mail if Unattended-Upgrade::Mail is set
-Unattended-Upgrade::MailOnlyOnError "<%= @unattended_upgrades['MailOnlyOnError'] %>";
+Unattended-Upgrade::MailOnlyOnError "<%= node['apt']['unattended_upgrades']['mail_only_on_error'] ? 'true' : 'false' %>";
 
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
-Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Remove-Unused-Dependencies "<%= node['apt']['unattended_upgrades']['remove_unused_dependencies'] ? 'true' : 'false' %>";
 
-// Automatically reboot *WITHOUT CONFIRMATION*
-//  if the file /var/run/reboot-required is found after the upgrade
-Unattended-Upgrade::Automatic-Reboot "<%= @unattended_upgrades['Automatic-Reboot'] %>";
+// Automatically reboot *WITHOUT CONFIRMATION* if a 
+// the file /var/run/reboot-required is found after the upgrade 
+Unattended-Upgrade::Automatic-Reboot "<%= node['apt']['unattended_upgrades']['automatic_reboot'] ? 'true' : 'false' %>";
 
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"
-Unattended-Upgrade::Automatic-Reboot-Time "<%= @unattended_upgrades['Automatic-Reboot-Time'] %>";
+<% if node['apt']['unattended_upgrades']['automatic_reboot'] -%>
+Unattended-Upgrade::Automatic-Reboot-Time "<%= node['apt']['unattended_upgrades']['automatic_reboot_time'] %>";
+<% end %>
 
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
-Acquire::http::Dl-Limit "<%= @unattended_upgrades['Dl-Limit'] %>";
+<% if node['apt']['unattended_upgrades']['dl_limit'] -%>
+Acquire::http::Dl-Limit "<%= node['apt']['unattended_upgrades']['dl_limit'] %>";
+<% end -%>

--- a/test/integration/default/serverspec/unattended_upgrades_spec.rb
+++ b/test/integration/default/serverspec/unattended_upgrades_spec.rb
@@ -7,8 +7,16 @@ describe package('unattended-upgrades') do
   it { should be_installed }
 end
 
+describe file('/etc/apt/apt.conf.d/20auto-upgrades') do
+  its(:content) do
+    should match(/APT::Periodic::Update-Package-Lists "1";/)
+    should match(/APT::Periodic::Unattended-Upgrade "1";/)
+  end
+end
+
 describe file('/etc/apt/apt.conf.d/50unattended-upgrades') do
   its(:content) do
+    should match(/\${distro_id}:\${distro_codename}-security/)
     should match(/Unattended-Upgrade::Mail "foo@example.com"/)
     should match(/Unattended-Upgrade::MailOnlyOnError "true"/)
     should match(/Unattended-Upgrade::Automatic-Reboot "true"/)


### PR DESCRIPTION
Closes #12.

I had to wrap the recipes:
  * the default uses mailutils instead of bsd-mailx
  * the 50unattended-upgrades template did not set reboot_time

Opened MR's for both:
 * https://github.com/opscode-cookbooks/apt/pull/108
 * https://github.com/opscode-cookbooks/apt/pull/107

You'll also notice I've redefined resource package[mailutils] as there's
a discrepancy between git repo and what supermarket api serves us. I
opened an issue for that here:
 * https://github.com/opscode-cookbooks/apt/issues/109